### PR TITLE
Office DDE/DDEAUTO attack disarm

### DIFF
--- a/Filtres/Filtre_XML.py
+++ b/Filtres/Filtre_XML.py
@@ -169,13 +169,9 @@ class Filtre_XML (Filtre.Filtre):
         """
         motifs = []
         motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
-            regex=r'ddeService="cmd"', remplacement='ddeService="___"'))
+            regex=r' ddeService(\s*)=(\s*)"[^_"]', remplacement=r' ddeService\1=\2"_'))
         motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
-            regex=r'ddeService="powershell"', remplacement='ddeService="__________"'))
-        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
-            regex=r'instrText>DDEAUTO c:', remplacement='instrText>_______ __'))
-        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
-            regex=r'instrText>DDE c:', remplacement='instrText>___ __'))
+            regex=r'<w:instrText>(\s*)DDE', remplacement=r'<w:instrText>\1___'))
         if len(motifs)>0:
             # Create a temporary file
             f_dest, chem_temp = newTempFile()

--- a/Filtres/Filtre_XML.py
+++ b/Filtres/Filtre_XML.py
@@ -101,6 +101,7 @@ except ImportError:
 from commun import *
 import Resultat, Conteneur
 import Filtre
+import thirdparty.RechercherRemplacer.RechercherRemplacer as RechercherRemplacer
 
 
 #=== CONSTANTES ===============================================================
@@ -137,6 +138,9 @@ class Filtre_XML (Filtre.Filtre):
     date = __date__
     version = __version__
 
+    def __init__ (self, politique, parametres=None):
+        Filtre.Filtre.__init__(self, politique, parametres)
+
     def reconnait_format(self, fichier):
         """
         analyse le format du fichier, et retourne True s'il correspond
@@ -153,8 +157,50 @@ class Filtre_XML (Filtre.Filtre):
         Retourne un code résultat suivant l'action effectuée.
         """
         # For now, let's just accept any XML without cleaning:
-        return self.resultat_accepte(fichier)
+        #return self.resultat_accepte(fichier)
+        return self.clean_simple_replace(fichier)
 
+    def clean_simple_replace (self, fichier):
+        """
+        Clean XML file using builtin simple replace method.
+        To be called from nettoyer() method.
+        Return Result object according to result.
+        Trigger an exception if an error occurs.
+        """
+        motifs = []
+        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
+            regex=r'ddeService="cmd"', remplacement='ddeService="___"'))
+        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
+            regex=r'ddeService="powershell"', remplacement='ddeService="__________"'))
+        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
+            regex=r'instrText>DDEAUTO c:', remplacement='instrText>_______ __'))
+        motifs.append( RechercherRemplacer.Motif(case_sensitive=False,
+            regex=r'instrText>DDE c:', remplacement='instrText>___ __'))
+        if len(motifs)>0:
+            # Create a temporary file
+            f_dest, chem_temp = newTempFile()
+            Journal.info2 (u"Temporary file: %s" % chem_temp)
+            # Open the source file
+            f_src = open(fichier.copie_temp(), 'rb')
+            Journal.info2 (u"Cleaning XML by replacing keywords")
+            n = RechercherRemplacer.rechercherRemplacer(motifs=motifs,
+                fich_src=f_src, fich_dest=f_dest, taille_identique=True, controle_apres=True)
+            f_src.close()
+            f_dest.close()
+            if n:
+                Journal.info2 (u"Tags in XML files have been disarmed.")
+                # File disarmed, replace original file
+                fichier.remplacer_copie_temp(chem_temp)
+                return self.resultat_nettoye(fichier)
+            else:
+                # No tag found
+                Journal.info2 (u"No XML tag disarmed.")
+                # Remove temporary file
+                os.remove(chem_temp)
+                return self.resultat_accepte(fichier)
+        else:
+            resultat = self.resultat_accepte(fichier)
+        return resultat
 
 #------------------------------------------------------------------------------
 # TESTS


### PR DESCRIPTION
Disarming of DDE attacks in office documents.

Works both with Word and Excel attacks that attempt to execute stuff through DDE/DDEAUTO launching cmd/powershell. 

Originally the exefilter XML filter does nothing, I've modified it to disarm the tags used to abuse DDE maliciously.
The approach is the same of the PDF filter: replacing tags to disarm them.

It has been tested with real samples of malicious documents.

Here is the relevant part of word/document.xml contained in a simulated malicious word file:

```xml
      <w:r w:rsidRPr="006E5453">                                                                                      
        <w:rPr>
          <w:rFonts w:ascii="Courier" w:hAnsi="Courier"/>
          <w:color w:val="222222"/>
          <w:sz w:val="24"/>
          <w:szCs w:val="24"/>
        </w:rPr>
        <w:instrText>DDEAUTO c:\</w:instrText>
      </w:r>
      <w:bookmarkStart w:id="0" w:name="_GoBack"/>
      <w:bookmarkEnd w:id="0"/>
      <w:r w:rsidRPr="006E5453">
        <w:rPr>
          <w:rFonts w:ascii="Courier" w:hAnsi="Courier"/>
          <w:color w:val="222222"/>
          <w:sz w:val="24"/>
          <w:szCs w:val="24"/>
        </w:rPr>
        <w:instrText>\windows\\system32\\cmd.exe "/k calc.exe"</w:instrText>
      </w:r>
```

And here is the disarmed version:

```xml
      <w:r w:rsidRPr="006E5453">                                                                                      
        <w:rPr>
          <w:rFonts w:ascii="Courier" w:hAnsi="Courier"/>
          <w:color w:val="222222"/>
          <w:sz w:val="24"/>
          <w:szCs w:val="24"/>
        </w:rPr>
        <w:instrText>_______ __\</w:instrText>
      </w:r>
      <w:bookmarkStart w:id="0" w:name="_GoBack"/>
      <w:bookmarkEnd w:id="0"/>
      <w:r w:rsidRPr="006E5453">
        <w:rPr>
          <w:rFonts w:ascii="Courier" w:hAnsi="Courier"/>
          <w:color w:val="222222"/>
          <w:sz w:val="24"/>
          <w:szCs w:val="24"/>
        </w:rPr>
        <w:instrText>\windows\\system32\\cmd.exe "/k calc.exe"</w:instrText>
      </w:r>

```
Here is the relevant part of xl/externalLinks/externalLink1.xml of a simulated malicious excel file:

```xml
<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" mc:Ignorable="x14">
  <ddeLink xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ddeService="cmd" ddeTopic="/c calc.exe">
    <ddeItems>
      <ddeItem name="_xlbgnm.A1" advise="1"/>
    </ddeItems>
  </ddeLink>
</externalLink>

```


And here is the disarmed version:

```xml
<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" mc:Ignorable="x14">
  <ddeLink xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ddeService="___" ddeTopic="/c calc.exe">
    <ddeItems>
      <ddeItem name="_xlbgnm.A1" advise="1"/>
    </ddeItems>
  </ddeLink>
</externalLink>   
```